### PR TITLE
Fix: Guard against undefined permissions and ensure profile is loaded

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -12,7 +12,7 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode
 }) {
-  const { user, loading } = useAuth()
+  const { user, loading, profile } = useAuth() // Added profile
   const router = useRouter()
 
   useEffect(() => {
@@ -21,7 +21,8 @@ export default function DashboardLayout({
     }
   }, [user, loading, router])
 
-  if (loading || !user) {
+  // If loading session, or no user, or profile not yet loaded
+  if (loading || !user || !profile) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
         <p>Loading dashboard...</p>

--- a/lib/role-config.ts
+++ b/lib/role-config.ts
@@ -170,8 +170,29 @@ export function hasPermission(role: UserRole, permission: keyof RolePermissions)
   return rolePermissions[role][permission]
 }
 
-export function getVisibleMenuItems(role: UserRole) {
-  const permissions = rolePermissions[role]
+export function getVisibleMenuItems(role?: UserRole) { // Allow role to be optional
+  const defaultMenuItems = [
+    {
+      title: "Overview",
+      url: "/dashboard",
+      icon: "Home",
+      visible: true,
+    },
+    {
+      title: "Profile",
+      url: "/dashboard/profile",
+      icon: "User",
+      visible: true, // Basic visibility for profile
+    },
+  ];
+
+  if (!role || !rolePermissions[role]) {
+    // If role is undefined, or not a valid key in rolePermissions,
+    // return a minimal safe menu.
+    return defaultMenuItems.filter(item => item.visible);
+  }
+
+  const permissions = rolePermissions[role];
 
   const menuItems = [
     {


### PR DESCRIPTION
- Modified `getVisibleMenuItems` in `lib/role-config.ts` to handle undefined roles, preventing a TypeError when accessing permission properties.
- Updated `app/dashboard/layout.tsx` to wait for `profile` to be loaded before rendering dashboard content, ensuring `permissions` from `useAuth` reflect the true state.