### PR TITLE
Refactor: Improve profile fetching and handle no-profile state

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -21,13 +21,42 @@ export default function DashboardLayout({
     }
   }, [user, loading, router])
 
-  // If loading session, or no user, or profile not yet loaded
-  if (loading || !user || !profile) {
+  const router = useRouter() // Ensure router is available
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/auth/login")
+    }
+  }, [user, loading, router])
+
+  // If loading session, or no user
+  if (loading || !user) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
-        <p>Loading dashboard...</p>
+        <p>Loading authentication...</p>
       </div>
     )
+  }
+
+  // If profile is not loaded yet (still null after user is loaded)
+  if (!profile) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <p>Loading profile...</p> {/* More specific loading message */}
+      </div>
+    )
+  }
+
+  // If profile fetch resulted in NO_PROFILE status
+  if (profile && (profile as any).status === 'NO_PROFILE') {
+    // Redirect to an onboarding page or show a specific message
+    // Assuming an onboarding page exists or will be created at /onboarding
+    router.push("/onboarding");
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <p>Redirecting to onboarding...</p>
+      </div>
+    );
   }
 
   return (

--- a/components/auth/auth-provider.tsx
+++ b/components/auth/auth-provider.tsx
@@ -60,16 +60,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const { data, error } = await supabase.from("profiles").select("*").eq("id", user.id).single()
 
         if (error) {
-          console.error("Error fetching profile:", error)
+          console.error("Error fetching profile:", error);
+          setProfile(null); // Explicitly set to null on error
+        } else if (!data) {
+          console.log(`No profile found for user ${user.id}. Redirecting to onboarding or setting default.`);
+          setProfile({ status: 'NO_PROFILE' }); // Special status for no profile
         } else {
-          setProfile(data)
+          setProfile(data);
         }
       }
       fetchProfile()
     } else if (!user) {
       setProfile(null)
     }
-  }, [user, profile])
+  }, [user?.id]) // Changed dependency from [user, profile] to [user?.id]
 
   // Handle logout
   const signOut = async () => {


### PR DESCRIPTION
- Changed useEffect dependency for profile fetching in AuthProvider to `user?.id` for stability.
- If no profile is found for a user, `profile` state is set to `{ status: 'NO_PROFILE' }`.
- DashboardLayout now checks for this status and redirects to `/onboarding`.
- Updated loading messages in DashboardLayout for better clarity.